### PR TITLE
Update assets-non-digest.rake

### DIFF
--- a/lib/tasks/assets-non-digest.rake
+++ b/lib/tasks/assets-non-digest.rake
@@ -2,7 +2,7 @@ require 'fileutils'
 
 desc "Create non-digest versions of all assets"
 task "assets:precompile" do
-  fingerprint = /\-[0-9a-f]{32}\./
+  fingerprint = /\-[0-9a-f]{32}?[0-9a-f]{32}\./
   jscolor_assets = ["arrow.gif", "cross.gif", "hs.png", "hv.png"]
   for file in Dir["public/assets/*"]
     next if file !~ fingerprint


### PR DESCRIPTION
sprockets use SHA256 for digests by default now*
so we shall allow both 32 or 64 hexadecimal symbols
as a length of a digest in the fingerprint

*: https://github.com/sstephenson/sprockets/pull/647
